### PR TITLE
Drops Gitlab CI badge referring to a GitHub repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT"
 readme = "README.md"
 
 [badges]
-gitlab = { repository = "https://github.com/hoverbear/digitalocean" }
 travis-ci = { repository = "hoverbear/digitalocean" }
 maintenance = { status = "experimental" }
 


### PR DESCRIPTION
I noticed it was breaking an image on the crate page when I was responding to rust-lang/crates.io#1148 just now.