### PR TITLE
Bump reqwest to 0.9.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ failure = "0.1.0"
 failure_derive = "0.1.1"
 lazy_static = "0.2.8"
 log = "0.3.8"
-reqwest = { version = "0.8.6", optional = true }
+reqwest = { version = "0.9.4", optional = true }
 serde = "1.0.11"
 serde_derive = "1.0.11"
 serde_json = "1.0.2"


### PR DESCRIPTION
I'm hitting sfackler/rust-openssl#994 when I try to use this lib. I've bumped `reqwest` to 0.9.4 which uses `native-tls` 0.2.2 which uses `openssl` 0.10.15. It might also be worth bumping this lib for another release.