### PR TITLE
Update dependencies, use 2018 Edition imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,16 @@ maintenance = { status = "experimental" }
 default = ["reqwest"]
 
 [dependencies]
-getset = "0.0.5"
-failure = "0.1.0"
-failure_derive = "0.1.1"
-lazy_static = "0.2.8"
-log = "0.3.8"
-reqwest = { version = "0.9.4", optional = true }
-serde = "1.0.11"
-serde_derive = "1.0.11"
-serde_json = "1.0.2"
-url = "1.5.1"
+getset = "0.0.6"
+failure = "0.1.5"
+failure_derive = "0.1.5"
+lazy_static = "1.3.0"
+log = "0.4.6"
+reqwest = { version = "0.9.11", optional = true }
+serde = "1.0.89"
+serde_derive = "1.0.89"
+serde_json = "1.0.39"
+url = "1.7.2"
 url_serde = "0.2.0"
 
 [dependencies.chrono]
@@ -38,9 +38,9 @@ features = ["serde"]
 version = "0.4.0"
 
 [dev-dependencies]
-dotenv = "0.10.0"
-env_logger = "0.4.3"
+dotenv = "0.13.0"
+env_logger = "0.6.1"
 
 [dev-dependencies.uuid]
 features = ["v4"]
-version = "0.5"
+version = "0.7.2"

--- a/examples/account.rs
+++ b/examples/account.rs
@@ -10,7 +10,7 @@ use std::env;
 // cargo run --example account
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init().ok();
+    env_logger::try_init().ok();
 
     let api_key = env::var("API_KEY").expect("API_KEY not set.");
     let client = DigitalOcean::new(api_key).unwrap();

--- a/examples/action.rs
+++ b/examples/action.rs
@@ -15,7 +15,7 @@ enum Choice {
 // cargo run --example action -- [--list [limit] | --id id]
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init().ok();
+    env_logger::try_init().ok();
 
     let api_key = env::var("API_KEY").expect("API_KEY not set.");
     let client = DigitalOcean::new(api_key).unwrap();

--- a/examples/droplet.rs
+++ b/examples/droplet.rs
@@ -14,7 +14,7 @@ use std::env;
 // cargo run --example droplet -- $ID $ACTION
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init().ok();
+    env_logger::try_init().ok();
 
     let api_key = env::var("API_KEY").expect("API_KEY not set.");
     let client = DigitalOcean::new(api_key).unwrap();

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -14,7 +14,7 @@ use std::env;
 // cargo run --example image -- $IMAGE --actions
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init().ok();
+    env_logger::try_init().ok();
 
     let mut args = env::args().skip(1);
 

--- a/examples/keys.rs
+++ b/examples/keys.rs
@@ -11,7 +11,7 @@ use std::env;
 // cargo run --example keys
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init().ok();
+    env_logger::try_init().ok();
 
     let api_key = env::var("API_KEY").expect("API_KEY not set.");
     let client = DigitalOcean::new(api_key).unwrap();

--- a/examples/records.rs
+++ b/examples/records.rs
@@ -12,7 +12,7 @@ use std::env;
 // cargo run --example records -- $DOMAIN $DOMAIN2...
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init().ok();
+    env_logger::try_init().ok();
 
     let api_key = env::var("API_KEY").expect("API_KEY not set.");
     let client = DigitalOcean::new(api_key).unwrap();

--- a/examples/sizes.rs
+++ b/examples/sizes.rs
@@ -10,7 +10,7 @@ use std::env;
 // cargo run --example sizes
 fn main() {
     dotenv::dotenv().ok();
-    env_logger::init().ok();
+    env_logger::try_init().ok();
 
     let api_key = env::var("API_KEY").expect("API_KEY not set.");
     let client = DigitalOcean::new(api_key).unwrap();

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -3,6 +3,7 @@ use crate::method::Get;
 use crate::request::AccountRequest;
 use crate::request::Request;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
+use getset::{Getters, Setters};
 
 const ACCOUNT_SEGMENT: &str = "account";
 

--- a/src/api/action.rs
+++ b/src/api/action.rs
@@ -5,6 +5,7 @@ use crate::request::ActionRequest;
 use crate::request::Request;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
 use chrono::{DateTime, Utc};
+use getset::{Getters, Setters};
 use url::Url;
 
 const ACTIONS_SEGMENT: &str = "actions";

--- a/src/api/certificate.rs
+++ b/src/api/certificate.rs
@@ -5,6 +5,7 @@ use crate::request::CertificateRequest;
 use crate::request::Request;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
 use chrono::{DateTime, Utc};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 use url::Url;

--- a/src/api/custom_image.rs
+++ b/src/api/custom_image.rs
@@ -4,6 +4,7 @@ use crate::request::CustomImageRequest;
 use crate::request::Request;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
 use chrono::{DateTime, Utc};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 

--- a/src/api/domain.rs
+++ b/src/api/domain.rs
@@ -4,6 +4,7 @@ use crate::method::{Create, Delete, Get, List};
 use crate::request::DomainRequest;
 use crate::request::Request;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 use std::net::IpAddr;

--- a/src/api/domain_record.rs
+++ b/src/api/domain_record.rs
@@ -4,6 +4,7 @@ use super::{HasPagination, HasResponse, HasValue};
 use crate::method::{Create, Delete, Get, List, Update};
 use crate::request::{DomainRecordRequest, DomainRequest};
 use crate::STATIC_URL_ERROR;
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 use url::Url;

--- a/src/api/droplet.rs
+++ b/src/api/droplet.rs
@@ -8,6 +8,7 @@ use crate::request::Request;
 use crate::request::{DropletRequest, SnapshotRequest};
 use crate::{ROOT_URL, STATIC_URL_ERROR};
 use chrono::{DateTime, Utc};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 use url::Url;

--- a/src/api/floating_ip.rs
+++ b/src/api/floating_ip.rs
@@ -5,6 +5,7 @@ use crate::method::{Create, Delete, Get, List};
 use crate::request::FloatingIpRequest;
 use crate::request::Request;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 use std::net::IpAddr;

--- a/src/api/image.rs
+++ b/src/api/image.rs
@@ -5,6 +5,7 @@ use crate::request::ImageRequest;
 use crate::request::Request;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
 use chrono::{DateTime, Utc};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 use url::Url;

--- a/src/api/load_balancer.rs
+++ b/src/api/load_balancer.rs
@@ -7,6 +7,7 @@ use crate::request::LoadBalancerRequest;
 use crate::request::Request;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
 use chrono::{DateTime, Utc};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 use std::net::IpAddr;

--- a/src/api/region.rs
+++ b/src/api/region.rs
@@ -4,6 +4,7 @@ use crate::method::List;
 use crate::request::RegionRequest;
 use crate::request::Request;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
+use getset::{Getters, Setters};
 use url::Url;
 
 const REGIONS_SEGMENT: &str = "regions";

--- a/src/api/region.rs
+++ b/src/api/region.rs
@@ -42,7 +42,7 @@ pub struct Region {
 }
 
 impl Region {
-    /// [Digital Ocean Documentation.](https://developers.digitalocean.com/documentation/v2/#create-a-new-domain)
+    /// [Digital Ocean Documentation.](https://developers.digitalocean.com/documentation/v2/#list-all-regions)
     pub fn list() -> RegionRequest<List, Vec<Region>> {
         let mut url = ROOT_URL.clone();
         url.path_segments_mut()

--- a/src/api/size.rs
+++ b/src/api/size.rs
@@ -4,6 +4,7 @@ use crate::method::List;
 use crate::request::Request;
 use crate::request::SizeRequest;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
+use getset::{Getters, Setters};
 use url::Url;
 
 const SIZES_SEGMENT: &str = "sizes";

--- a/src/api/snapshot.rs
+++ b/src/api/snapshot.rs
@@ -5,6 +5,7 @@ use crate::request::Request;
 use crate::request::SnapshotRequest;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
 use chrono::{DateTime, Utc};
+use getset::{Getters, Setters};
 use url::Url;
 
 const SNAPSHOT_SEGMENT: &str = "snapshots";

--- a/src/api/ssh_key.rs
+++ b/src/api/ssh_key.rs
@@ -4,6 +4,7 @@ use crate::method::{Create, Delete, Get, List, Update};
 use crate::request::Request;
 use crate::request::SshKeyRequest;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 use url::Url;

--- a/src/api/tag.rs
+++ b/src/api/tag.rs
@@ -4,6 +4,7 @@ use crate::method::{Create, Delete, Get, List};
 use crate::request::Request;
 use crate::request::TagRequest;
 use crate::{ROOT_URL, STATIC_URL_ERROR};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use serde_json::Value;
 use std::fmt::Display;

--- a/src/api/volume.rs
+++ b/src/api/volume.rs
@@ -7,6 +7,7 @@ use crate::request::Request;
 use crate::request::{SnapshotRequest, VolumeRequest};
 use crate::{ROOT_URL, STATIC_URL_ERROR};
 use chrono::{DateTime, Utc};
+use getset::{Getters, Setters};
 use serde::Serialize;
 use std::fmt::Display;
 use url::Url;

--- a/src/client/reqwest.rs
+++ b/src/client/reqwest.rs
@@ -6,6 +6,7 @@ use crate::method::{Create, Delete, Get, List, Update};
 use crate::request::Request;
 use crate::DigitalOcean;
 use failure::Error;
+use log::info;
 use reqwest::StatusCode;
 use reqwest::{RequestBuilder, Response};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,14 +89,10 @@ Please just open an issue or PR!
 
 */
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
+use lazy_static::lazy_static;
+use log::info;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate getset;
 #[macro_use]
 extern crate serde_json;
 #[macro_use]

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,6 +6,7 @@ use crate::api::{HasPagination, HasResponse};
 use crate::method::{Create, Delete, Get, List, Method, Update};
 use crate::DigitalOcean;
 use failure::Error;
+use getset::{Getters, MutGetters, Setters};
 use serde_json::Value;
 use std::marker::PhantomData;
 use url::Url;

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -4,5 +4,5 @@ extern crate env_logger;
 pub fn before() {
     // Setup for tests
     dotenv::dotenv().ok();
-    env_logger::init().ok();
+    env_logger::try_init().ok();
 }


### PR DESCRIPTION
Since #19 we can now use `use` imports for everything.

Took some time to bump dependencies.